### PR TITLE
#27 teamsで参加者の検知が出来ていなかった問題を修正

### DIFF
--- a/WebMeetingParticipantChecker/Models/UIAutomation/UserNameElementGetterForTeams.cs
+++ b/WebMeetingParticipantChecker/Models/UIAutomation/UserNameElementGetterForTeams.cs
@@ -30,20 +30,7 @@ namespace WebMeetingParticipantChecker.Models.UIAutomation
                 {
                     continue;
                 }
-                // 2要素目の子の子が名前の要素のため、そこまでたどる
-                var walker = _automation.CreateTreeWalker(GetConditionForChildren());
-                var firstChild = walker.GetFirstChildElement(item);
-                if (firstChild?.CurrentName == null)
-                {
-                    continue;
-                }
-                var secondChild = walker.GetNextSiblingElement(firstChild);
-                if (secondChild?.CurrentName == null)
-                {
-                    continue;
-                }
-                var secondChildsChild = walker.GetFirstChildElement(secondChild);
-                elements.Add(secondChildsChild ?? item);
+                elements.Add(item);
             }
             return new UIAutomationElementArray(elements);
         }


### PR DESCRIPTION
teamsで参加者の各要素取得が、ツリーをたどらずにTreeItemControlTypeの指定で取得できていた。 そのため子要素をたどらず取れたもの一覧に参加者の各要素が含まれている想定の動作に修正